### PR TITLE
fix breaking change and update version & docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 # react-native-contact-picker
 
 * Support to open contact sheet and select a user and get their emails back.
-* Note: will not work on for Android on versions below React Native 40 due to a breaking change in React Native
+
+Library | React Native
+--------|-------------
+4 | 47+
+3 | 40-46
+2 | <=39
 
 ## Getting started
 

--- a/android/src/main/java/com/doctadre/contactpicker/ContactPickerPackage.java
+++ b/android/src/main/java/com/doctadre/contactpicker/ContactPickerPackage.java
@@ -27,11 +27,6 @@ public class ContactPickerPackage implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Arrays.asList();
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-contact-picker",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "A contact picker module for React Native",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
RN 47 has a breaking change and has deprecated use of the createJSModules function.  It can be left in but you have to at least remove the `@override` but since there are no other changes in the lib, I thought I'd just remove the function entirely